### PR TITLE
Add xacro argument to enable Gazebo control

### DIFF
--- a/op3_description/urdf/robotis_op3.gazebo.xacro
+++ b/op3_description/urdf/robotis_op3.gazebo.xacro
@@ -183,10 +183,7 @@
         <plugin>gz_ros2_control/GazeboSimSystem</plugin>
       </hardware>
       <joint name="r_sho_pitch">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -195,10 +192,7 @@
       </joint>
       
       <joint name="l_sho_pitch">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -207,10 +201,7 @@
       </joint>
 
       <joint name="r_sho_roll">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -219,10 +210,7 @@
       </joint>
 
       <joint name="l_sho_roll">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -231,10 +219,7 @@
       </joint>
 
       <joint name="r_el">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -243,10 +228,7 @@
       </joint>
 
       <joint name="l_el">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -255,10 +237,7 @@
       </joint>
 
       <joint name="r_hip_yaw">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -267,10 +246,7 @@
       </joint>
 
       <joint name="l_hip_yaw">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -279,10 +255,7 @@
       </joint>
 
       <joint name="r_hip_roll">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -291,10 +264,7 @@
       </joint>
 
       <joint name="l_hip_roll">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -303,10 +273,7 @@
       </joint>
 
       <joint name="r_hip_pitch">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -315,10 +282,7 @@
       </joint>
 
       <joint name="l_hip_pitch">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -327,10 +291,7 @@
       </joint>
 
       <joint name="r_knee">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -339,10 +300,7 @@
       </joint>
 
       <joint name="l_knee">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -351,10 +309,7 @@
       </joint>
 
       <joint name="r_ank_pitch">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -363,10 +318,7 @@
       </joint>
 
       <joint name="l_ank_pitch">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -375,10 +327,7 @@
       </joint>
 
       <joint name="r_ank_roll">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -387,10 +336,7 @@
       </joint>
 
       <joint name="l_ank_roll">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -399,10 +345,7 @@
       </joint>
 
       <joint name="head_pan">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -411,10 +354,7 @@
       </joint>
 
       <joint name="head_tilt">
-        <command_interface name="position">
-          <param name="min">-3.14</param>
-          <param name="max">3.14</param>
-        </command_interface>
+        <command_interface name="position"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>

--- a/op3_description/urdf/robotis_op3.gazebo.xacro
+++ b/op3_description/urdf/robotis_op3.gazebo.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="robotis_op3_gazebo">
+  <xacro:macro name="robotis_op3_gazebo" params="gazebo_controllers_param_file">
 
     <gazebo reference="body_link">
       <mu1>0.2</mu1>
@@ -169,7 +169,7 @@
     <!-- For Gazebo Control and Sensors -->
     <gazebo>
       <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
-        <parameters>$(find op3_gazebo_ros2)/config/robotis_op3_gazebo_config.yaml</parameters>
+        <parameters>${gazebo_controllers_param_file}</parameters>
       </plugin>
       <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
         <render_engine>ogre2</render_engine>

--- a/op3_description/urdf/robotis_op3.gazebo.xacro
+++ b/op3_description/urdf/robotis_op3.gazebo.xacro
@@ -187,6 +187,263 @@
       </plugin>
     </gazebo>
 
+    <!-- For Gazebo Control and Sensors -->
+    <gazebo>
+      <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+        <parameters>$(find op3_gazebo_ros2)/config/robotis_op3_gazebo_config.yaml</parameters>
+      </plugin>
+      <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
+        <render_engine>ogre2</render_engine>
+      </plugin>
+      <plugin filename="gz-sim-imu-system" name="gz::sim::systems::Imu"/>
+    </gazebo>
+
+    <!-- For Ros2 Control -->
+    <ros2_control name="GazeboSimSystem" type="system">
+      <hardware>
+        <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      </hardware>
+      <joint name="r_sho_pitch">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+      
+      <joint name="l_sho_pitch">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="r_sho_roll">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="l_sho_roll">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="r_el">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="l_el">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="r_hip_yaw">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="l_hip_yaw">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="r_hip_roll">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="l_hip_roll">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="r_hip_pitch">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="l_hip_pitch">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="r_knee">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="l_knee">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="r_ank_pitch">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="l_ank_pitch">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="r_ank_roll">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="l_ank_roll">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="head_pan">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <joint name="head_tilt">
+        <command_interface name="position">
+          <param name="min">-3.14</param>
+          <param name="max">3.14</param>
+        </command_interface>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+    </ros2_control>
+
     <gazebo reference="cam_gazebo_link">
       <sensor name='camera' type='camera'>
         <gz_frame_id>cam_gazebo_link</gz_frame_id>

--- a/op3_description/urdf/robotis_op3.gazebo.xacro
+++ b/op3_description/urdf/robotis_op3.gazebo.xacro
@@ -6,7 +6,6 @@
     <gazebo reference="body_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
@@ -14,35 +13,30 @@
     <gazebo reference="l_hip_yaw_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="l_hip_roll_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="l_hip_pitch_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="l_knee_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="l_ank_pitch_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
@@ -54,42 +48,36 @@
       <fdir1>1 0 0</fdir1>
       <maxVel>1.0</maxVel>
       <minDepth>0.001</minDepth>
-      <material>Gazebo/White</material>
     </gazebo>
 
     <!-- right leg links -->
     <gazebo reference="r_hip_yaw_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="r_hip_roll_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="r_hip_pitch_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="r_knee_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="r_ank_pitch_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
@@ -102,62 +90,53 @@
       <fdir1>1 0 0</fdir1>
       <maxVel>1.0</maxVel>
       <minDepth>0.001</minDepth>
-      <material>Gazebo/White</material>
     </gazebo>
 
     <gazebo reference="r_sho_pitch_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="r_sho_roll_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="r_el_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="l_sho_pitch_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="l_sho_roll_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="l_el_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="head_pan_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo>
 
     <gazebo reference="head_tilt_link">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/White</material>
       <selfCollide>false</selfCollide>
     </gazebo> 
 

--- a/op3_description/urdf/robotis_op3.urdf.xacro
+++ b/op3_description/urdf/robotis_op3.urdf.xacro
@@ -1,6 +1,8 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="robotis_op3">
 
+  <xacro:arg name="use_sim" default="false"/>
+
   <xacro:include filename="$(find op3_description)/urdf/robotis_op3.visuals.xacro" />
   <xacro:include filename="$(find op3_description)/urdf/robotis_op3.inertia.xacro" />
 
@@ -12,7 +14,9 @@
 
   <xacro:include filename="$(find op3_description)/urdf/robotis_op3.structure.head.xacro" />
 
-  <!-- <xacro:include filename="$(find op3_description)/urdf/robotis_op3.ros2.gazebo.xacro" /> -->
+  <xacro:if value="$(arg use_sim)">
+    <xacro:include filename="$(find op3_description)/urdf/robotis_op3.gazebo.xacro" />
+  </xacro:if>
   
   <link name="base"/>
 
@@ -52,6 +56,9 @@
   <!-- head links -->
   <xacro:robotis_op3_head parent="body_link" />  
 
-  <!-- <xacro:robotis_op3_gazebo/> -->
+  <!-- gazebo / ros2_control -->
+  <xacro:if value="$(arg use_sim)">
+    <xacro:robotis_op3_gazebo/>
+  </xacro:if>
 
 </robot>

--- a/op3_description/urdf/robotis_op3.urdf.xacro
+++ b/op3_description/urdf/robotis_op3.urdf.xacro
@@ -2,6 +2,7 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="robotis_op3">
 
   <xacro:arg name="use_sim" default="false"/>
+  <xacro:arg name="gazebo_controllers_param_file" default="$(find op3_gazebo_ros2)/config/robotis_op3_gazebo_config.yaml"/>
 
   <xacro:include filename="$(find op3_description)/urdf/robotis_op3.visuals.xacro" />
   <xacro:include filename="$(find op3_description)/urdf/robotis_op3.inertia.xacro" />
@@ -14,9 +15,7 @@
 
   <xacro:include filename="$(find op3_description)/urdf/robotis_op3.structure.head.xacro" />
 
-  <xacro:if value="$(arg use_sim)">
-    <xacro:include filename="$(find op3_description)/urdf/robotis_op3.gazebo.xacro" />
-  </xacro:if>
+  <xacro:include filename="$(find op3_description)/urdf/robotis_op3.gazebo.xacro" />
   
   <link name="base"/>
 
@@ -58,7 +57,7 @@
 
   <!-- gazebo / ros2_control -->
   <xacro:if value="$(arg use_sim)">
-    <xacro:robotis_op3_gazebo/>
+    <xacro:robotis_op3_gazebo gazebo_controllers_param_file="$(arg gazebo_controllers_param_file)"/>
   </xacro:if>
 
 </robot>


### PR DESCRIPTION
This change is to enable `ros2_control` for the OP3 robot when running in simulation in Gazebo. Currently the instructions (https://emanual.robotis.com/docs/en/platform/op3/simulation/#how-to-execute-gazebo-simulation) do not work as the controllers are not loaded.

### Details

Add the `ros2_control` element and `gz_ros2_control-system` to `robotis_op3.gazebo.xacro`. These are taken from https://github.com/Jay-Song/op3_gazebo_ros2/blob/main/gazebo/robotis_op3.gazebo.xacro.

Add an xacro argument `use_sim` to conditionally include `robotis_op3.gazebo.xacro` when true.

The downstream launch file `robot_sim.launch.py` in `op3_gazebo_ros2`  already sets `use_sim` to true when processing the robot xacro file.

With this change the robot and ros2_controllers will launch correctly, and the motion modules provided in `op3_manager` are able to actuate the robot.

### Other changes

Recent versions of Gazebo do not support material scripts. To prevent numerous warnings when loading the model the `<material>Gazebo/White</material>` elements are removed from the Gazebo xacro.
